### PR TITLE
Update star map to swap views without reload

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,10 +61,27 @@
     <div class="planet urano" style="top: 75%; left: 60%;">💡 Urano em Touro 💡</div>
     <div class="planet netuno" style="top: 80%; left: 40%;">🌊 Netuno em Peixes 🌊</div>
     <div class="planet plutao" style="top: 85%; left: 20%;">🏹 Plutão em Aquário 🏹</div>
-    <div class="planet lua" style="top: 10%; left: 20%;">🌙 Lua em Aquário 🌙</div>
+  <div class="planet lua" style="top: 10%; left: 20%;">🌙 Lua em Aquário 🌙</div>
+  </div>
+  <main id="birth-container" class="container hidden">
+    <h1>O céu quando você nasceu ✨</h1>
+    <p class="shooting-star">Um instante cósmico que te envolveu em magia e inspirou todos os caminhos que viriam.</p>
+  </main>
+  <div id="birth-sky-container" style="opacity:0; visibility:hidden;">
+    <div class="planet sol" style="top: 20%; left: 60%;">☀️ Sol em Aquário ☀️</div>
+    <div class="planet mercurio" style="top: 30%; left: 40%;">🧠 Mercúrio em Capricórnio 🧠</div>
+    <div class="planet venus" style="top: 40%; left: 25%;">💖 Vênus em Peixes 💖</div>
+    <div class="planet marte" style="top: 50%; left: 70%;">🔥 Marte em Áries 🔥</div>
+    <div class="planet jupiter" style="top: 60%; left: 50%;">🌱 Júpiter em Virgem 🌱</div>
+    <div class="planet saturno" style="top: 65%; left: 30%;">⏳ Saturno em Câncer ⏳</div>
+    <div class="planet urano" style="top: 75%; left: 60%;">💡 Urano em Peixes 💡</div>
+    <div class="planet netuno" style="top: 80%; left: 40%;">🌊 Netuno em Aquário 🌊</div>
+    <div class="planet plutao" style="top: 85%; left: 20%;">🏹 Plutão em Sagitário 🏹</div>
+    <div class="planet lua" style="top: 10%; left: 20%;">🌙 Lua em Peixes 🌙</div>
   </div>
   <div id="tooltip"></div>
   <script src="script.js"></script>
+  <button id="next-page-btn" aria-label="Abrir mapa do céu">➡️</button>
   <button id="play-pause-btn" aria-label="Reproduzir/Pausar música de fundo">▶️</button>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,19 +1,19 @@
 document.addEventListener("DOMContentLoaded", () => {
     const giftBox = document.getElementById("gift-box");
     const skyContainer = document.getElementById("sky-container");
+    const birthContainer = document.getElementById("birth-container");
+    const birthSkyContainer = document.getElementById("birth-sky-container");
     const kickElementsWrapper = document.getElementById("kick-elements-wrapper");
     const allStar = document.getElementById("allstar");
     const explosion = document.getElementById("explosion");
     const tooltip = document.getElementById("tooltip");
     const bgMusic = document.getElementById("bg-music");
     const playPauseBtn = document.getElementById("play-pause-btn");
+    const nextPageBtn = document.getElementById("next-page-btn");
     const mainContainer = document.querySelector(".container");
 
-    const planets = [...document.querySelectorAll(".planet")];
-    let currentPlanetIndex = planets.findIndex(p => p.classList.contains("sol"));
-    if (currentPlanetIndex === -1) {
-        currentPlanetIndex = 0;
-    }
+    let planets = [];
+    let currentPlanetIndex = 0;
 
     const titleText = " Assim estava o céu quando os rumos de nossas vidas se encontraram 💜";
     let titleIndex = 0;
@@ -119,8 +119,9 @@ document.addEventListener("DOMContentLoaded", () => {
             skyContainer.style.visibility = "visible";
             skyContainer.style.opacity = "1";
             playPauseBtn.style.display = "inline-block";
-
-            currentPlanetIndex = planets.findIndex(p => p.classList.contains("sol"));
+            nextPageBtn.style.display = "inline-block";
+            planets = [...skyContainer.querySelectorAll('.planet')];
+            currentPlanetIndex = planets.findIndex(p => p.classList.contains('sol'));
             if (currentPlanetIndex === -1) {
                 currentPlanetIndex = 0;
             }
@@ -235,6 +236,28 @@ document.addEventListener("DOMContentLoaded", () => {
             });
         });
     }
+
+    function showBirthChart() {
+        skyContainer.style.opacity = '0';
+        skyContainer.style.visibility = 'hidden';
+
+        birthContainer.classList.remove('hidden');
+        birthSkyContainer.style.visibility = 'visible';
+        birthSkyContainer.style.opacity = '1';
+        nextPageBtn.style.display = 'none';
+
+        planets = [...birthSkyContainer.querySelectorAll('.planet')];
+        currentPlanetIndex = planets.findIndex(p => p.classList.contains('sol'));
+        if (currentPlanetIndex === -1) {
+            currentPlanetIndex = 0;
+        }
+        startMessageLoop();
+        addPlanetHoverListeners();
+    }
+
+    nextPageBtn.addEventListener('click', showBirthChart);
+
+    nextPageBtn.addEventListener('wheel', showBirthChart);
 
     updateMusicButtonState();
 });

--- a/style.css
+++ b/style.css
@@ -213,7 +213,8 @@ h1 {
     will-change: transform, opacity;
 }
 
-#sky-container {
+#sky-container,
+#birth-sky-container {
     position: fixed;
     top: 0; left: 0; right: 0; bottom: 0;
     width: 100vw;
@@ -312,6 +313,30 @@ h1 {
 }
 
 #play-pause-btn:hover {
+    background: rgba(255, 255, 255, 0.3);
+}
+
+#next-page-btn {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    transform: none;
+    background: rgba(255, 255, 255, 0.15);
+    border: none;
+    border-radius: 30px;
+    padding: 12px 20px;
+    font-size: 1.5rem;
+    color: white;
+    cursor: pointer;
+    backdrop-filter: blur(8px);
+    box-shadow: 0 0 10px rgba(255, 255, 255, 0.2);
+    z-index: 150;
+    transition: background-color 0.3s ease;
+    user-select: none;
+    display: none;
+}
+
+#next-page-btn:hover {
     background: rgba(255, 255, 255, 0.3);
 }
 


### PR DESCRIPTION
## Summary
- embed natal chart markup directly in `index.html`
- style both sky containers
- swap containers with JavaScript instead of navigating
- remove the unused `mapa.html`

## Testing
- `node --check script.js`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6871465965208323881b06ac19d60d02